### PR TITLE
Support Capacitor 2.x on Android

### DIFF
--- a/CapacitorRateApp.podspec
+++ b/CapacitorRateApp.podspec
@@ -1,7 +1,7 @@
 
   Pod::Spec.new do |s|
     s.name = 'CapacitorRateApp'
-    s.version = '0.0.1'
+    s.version = '0.0.2'
     s.summary = 'Rate your app in stores'
     s.license = 'MIT'
     s.homepage = '-'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         release {
@@ -40,8 +40,9 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
+    testImplementation "junit:junit:$junitVersion"
+    androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
 }
 

--- a/android/src/androidTest/java/com/getcapacitor/android/ExampleInstrumentedTest.java
+++ b/android/src/androidTest/java/com/getcapacitor/android/ExampleInstrumentedTest.java
@@ -1,8 +1,8 @@
 package com.getcapacitor.android;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/android/src/main/res/layout/bridge_layout_main.xml
+++ b/android/src/main/res/layout/bridge_layout_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -12,4 +12,4 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent" />
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-rate-app",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Rate your app in stores",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
The current plugin will not work properly on Android with Capacitor 2.x because Capacitor 2 requires AndroidX. This PR encompasses the minimal changes needed to support AndroidX. This fixes issue #2 