### PR TITLE
fix(android): replace proguard-android.txt with proguard-android-optimize.txt for AGP 9 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {


### PR DESCRIPTION
Resolves #96.

AGP 9 dropped support for `getDefaultProguardFile('proguard-android.txt')` because it bundled `-dontoptimize`, which neutered R8 optimizations. Under AGP 9 the build fails with:

```
getDefaultProguardFile('proguard-android.txt') is no longer supported since it includes `-dontoptimize`...
```

Switching to `proguard-android-optimize.txt` (the default Android Studio template's recommended file for years) keeps the plugin evaluating cleanly under AGP 8 and AGP 9.

One-line change in `android/build.gradle:34`. No behavioral impact for consumers on AGP 8 (the optimize variant is functionally equivalent for a library plugin with `minifyEnabled false`).